### PR TITLE
Fix gulp asynchronous errors

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,13 +19,13 @@ gulp.task('build-success', () => notifier.notify({
  * Runs through directory and watches for modified files.
  */
 gulp.task('watch', () => {
-	gulp.watch('src/assets/**/*', ['copy']);
+	gulp.watch('src/assets/**/*', ['copy', 'views', 'css', 'js']);
 	gulp.watch(
 		['src/views/**/*.html', 'src/i18n/**/*.json', 'src/includes/**/*.html'],
-		['views']
+		['copy', 'views', 'css', 'js']
 	);
-	gulp.watch('src/scss/**/*.scss', ['css']);
-	gulp.watch('src/scripts/es6/**/*.js', ['js']);
+	gulp.watch('src/scss/**/*.scss', ['copy', 'views', 'css', 'js']);
+	gulp.watch('src/scripts/es6/**/*.js', ['copy', 'views', 'css', 'js']);
 });
 
 /**

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -5,7 +5,7 @@ const dist = 'public';
  * Task: gulp copy
  * Move all assets.
  */
-gulp.task('copy', () =>
+gulp.task('copy', ['clean'], () =>
 	gulp.src('src/assets/**/*', { base: 'src' })
 	.pipe( gulp.dest(dist) )
 );

--- a/tasks/css.js
+++ b/tasks/css.js
@@ -9,7 +9,7 @@ const dist = 'public';
  * Task: gulp css
  * Compile Sass to valid CSS, add prefix and minify.
  */
-gulp.task('css', () => gulp.src('src/scss/main.scss')
+gulp.task('css', ['clean'], () => gulp.src('src/scss/main.scss')
 	.pipe( sass({ style: 'compact' }) )
 	.pipe( autoprefixer('last 2 versions') )
 	.pipe( rename({ suffix: '.min' }) )

--- a/tasks/scripts.js
+++ b/tasks/scripts.js
@@ -13,7 +13,7 @@ const dist = 'public';
  * Task: gulp lint
  * Lints ES6.
  */
-gulp.task('lint', () => gulp.src('src/scripts/es6/**/*.js')
+gulp.task('lint', ['clean'], () => gulp.src('src/scripts/es6/**/*.js')
 	.pipe( eslint() )
 	.pipe( eslint.format(tap) )
 	.pipe( eslint.failOnError() )

--- a/tasks/server.js
+++ b/tasks/server.js
@@ -5,7 +5,7 @@ const connect = require('gulp-connect');
  * Task: gulp server
  * Starts the web server.
  */
-gulp.task('server', () => {
+gulp.task('server', ['clean'], () => {
 	connect.server({
 		port: 9000,
 		root: 'public'

--- a/tasks/views.js
+++ b/tasks/views.js
@@ -8,7 +8,7 @@ const dist = 'public';
  * Task: gulp views
  * Creates all markup templates.
  */
-gulp.task('views', () => gulp.src('src/views/**/*.html')
+gulp.task('views', ['clean'], () => gulp.src('src/views/**/*.html')
 	.pipe( fileinclude({
 		prefix: '@@',
 		basepath: 'src/includes/'


### PR DESCRIPTION
Make `clean` task always before `copy`, `css`, `scripts`, `server` and `views` task. The change required changing the watch task: While watching always make `['copy', 'views', 'css', 'js']` tasks, when files were changed.

Should fix issue #9.
